### PR TITLE
Fix(vocabulary): Vocabulary의 Nationality 값을 모두 RawValue 취급하도록 로직을 수정함.

### DIFF
--- a/GGomVoca/GGomVoca/Configuration/UserManager.swift
+++ b/GGomVoca/GGomVoca/Configuration/UserManager.swift
@@ -28,13 +28,13 @@ final class UserManager {
     // MARK: 단어장 추가
     static func addVocabulary(id: String, nationality: String) {
         switch nationality {
-        case "KO":
+        case Nationality.KO.rawValue:
             shared.koreanVocabularyIDs.append(id)
-        case "EN":
+        case Nationality.EN.rawValue:
             shared.englishVocabularyIDs.append(id)
-        case "JA":
+        case Nationality.JA.rawValue:
             shared.japanishVocabularyIDs.append(id)
-        case "FR":
+        case Nationality.FR.rawValue:
             shared.frenchVocabularyIDs.append(id)
         default:
             break

--- a/GGomVoca/GGomVoca/View/DisplaySplitView/AddVocabularyView.swift
+++ b/GGomVoca/GGomVoca/View/DisplaySplitView/AddVocabularyView.swift
@@ -52,7 +52,7 @@ struct AddVocabularyView: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("완료") {
                         //addVocabulary() // MARK: Deprecated
-                        addCompletion(self.vocabularyName, "\(self.nationality)")
+                        addCompletion(self.vocabularyName, self.nationality.rawValue)
                         dismiss()
                     }
                     /// - 단어장 이름이 공백인 경우 버튼 비활성화

--- a/GGomVoca/GGomVoca/View/DisplaySplitView/Cell/VocabularyCell.swift
+++ b/GGomVoca/GGomVoca/View/DisplaySplitView/Cell/VocabularyCell.swift
@@ -27,13 +27,13 @@ struct VocabularyCell: View {
     
     private var natianalityIcon: String {
         switch vocabulary.nationality {
-        case "KO":
+        case Nationality.KO.rawValue:
             return "🇰🇷"
-        case "EN":
+        case Nationality.EN.rawValue:
             return "🇺🇸"
-        case "JA":
+        case Nationality.JA.rawValue:
             return "🇯🇵"
-        case "FR":
+        case Nationality.FR.rawValue:
             return "🇫🇷"
         default:
             return ""

--- a/GGomVoca/GGomVoca/View/DisplaySplitView/DisplaySplitView.swift
+++ b/GGomVoca/GGomVoca/View/DisplaySplitView/DisplaySplitView.swift
@@ -39,17 +39,17 @@ struct DisplaySplitView: View {
         } detail: {
             if let selectedVocabulary {
                 NavigationStack {
-                    switch selectedVocabulary.nationality {
-                    case "KO":
+                    switch Nationality(rawValue: selectedVocabulary.nationality ?? "") {
+                    case .KO:
                         KOWordListView(vocabularyID: selectedVocabulary.id)
                             .id(selectedVocabulary.id)
-                    case "EN" :
+                    case .EN :
                         ENWordListView(vocabularyID: selectedVocabulary.id)
                             .id(selectedVocabulary.id)
-                    case "JA" :
+                    case .JA :
                         JPWordListView(vocabularyID: selectedVocabulary.id)
                             .id(selectedVocabulary.id)
-                    case "FR" :
+                    case .FR :
                         FRWordListView(vocabularyID: selectedVocabulary.id)
                             .id(selectedVocabulary.id)
                     default:

--- a/GGomVoca/GGomVoca/View/DisplaySplitView/EditVocabularyView.swift
+++ b/GGomVoca/GGomVoca/View/DisplaySplitView/EditVocabularyView.swift
@@ -44,18 +44,19 @@ struct EditVocabularyView: View {
             .navigationBarTitle("단어장 제목 변경")
             .onAppear {
                 inputVocabularyName = vocabulary.name ?? ""
-                switch vocabulary.nationality ?? "" {
-                case "KO":
-                    nationality = .KO
-                case "EN":
-                    nationality = .EN
-                case "JA":
-                    nationality = .JA
-                case "FR":
-                    nationality = .FR
-                default:
-                    break
-                }
+                nationality = Nationality(rawValue: vocabulary.nationality ?? "") ?? .KO
+//                switch vocabulary.nationality ?? "" {
+//                case "KO" :
+//                    nationality = .KO
+//                case "EN":
+//                    nationality = .EN
+//                case "JA":
+//                    nationality = .JA
+//                case "FR":
+//                    nationality = .FR
+//                default:
+//                    break
+//                }
                 print(nationality)
             }
             .toolbar {

--- a/GGomVoca/GGomVoca/View/WordListView/CommonView/EmptyWordListView.swift
+++ b/GGomVoca/GGomVoca/View/WordListView/CommonView/EmptyWordListView.swift
@@ -12,13 +12,13 @@ struct EmptyWordListView: View {
     var lang: String
     var langNationality: Nationality {
         switch lang {
-        case "KO":
+        case Nationality.KO.rawValue:
             return .KO
-        case "EN":
+        case Nationality.EN.rawValue:
             return .EN
-        case "FR":
+        case Nationality.FR.rawValue:
             return .FR
-        case "JA":
+        case Nationality.JA.rawValue:
             return .JA
         default:
             return .KO
@@ -26,13 +26,13 @@ struct EmptyWordListView: View {
     }
     var emptyByLang: String {
         switch lang {
-        case "KO":
+        case Nationality.KO.rawValue:
             return "비어 있는"
-        case "EN":
+        case Nationality.EN.rawValue:
             return "empty"
-        case "FR":
+        case Nationality.FR.rawValue:
             return "vide"
-        case "JA":
+        case Nationality.JA.rawValue:
             return "空っぽの"
         default:
             return ""

--- a/GGomVoca/GGomVoca/View/WordListView/ENWordList/ENWordListViewModel.swift
+++ b/GGomVoca/GGomVoca/View/WordListView/ENWordList/ENWordListViewModel.swift
@@ -114,13 +114,13 @@ class ENENWordListViewModel: ObservableObject {
   func getEmptyWord() -> String {
     var emptyMsg: String {
       switch nationality {
-      case "KO":
+      case Nationality.KO.rawValue:
         return "비어 있는"
-      case "EN":
+      case Nationality.EN.rawValue:
         return "Empty"
-      case "JA":
+      case Nationality.JA.rawValue:
         return "空っぽの"
-      case "FR":
+      case Nationality.FR.rawValue:
         return "Vide"
       case "CH":
         return "空"

--- a/GGomVoca/GGomVoca/View/WordListView/FRWordList/FRWordListViewModel.swift
+++ b/GGomVoca/GGomVoca/View/WordListView/FRWordList/FRWordListViewModel.swift
@@ -113,13 +113,13 @@ class FRFRWordListViewModel: ObservableObject {
     func getEmptyWord() -> String {
         var emptyMsg: String {
             switch nationality {
-            case "KO":
+            case Nationality.KO.rawValue:
                 return "비어 있는"
-            case "EN":
+            case Nationality.EN.rawValue:
                 return "Empty"
-            case "JA":
+            case Nationality.JA.rawValue:
                 return "空っぽの"
-            case "FR":
+            case Nationality.FR.rawValue:
                 return "Vide"
             case "CH":
                 return "空"

--- a/GGomVoca/GGomVoca/View/WordListView/KOWordList/KOWordListViewModel.swift
+++ b/GGomVoca/GGomVoca/View/WordListView/KOWordList/KOWordListViewModel.swift
@@ -22,7 +22,7 @@ class KOWordListViewModel: ObservableObject {
     
   // MARK: Vocabulary Properties
   var selectedVocabulary: Vocabulary = Vocabulary()
-  var nationality: String = "KO"
+  var nationality: String = Nationality.KO.rawValue
 
   @Published var words: [Word] = []
 
@@ -116,13 +116,13 @@ class KOWordListViewModel: ObservableObject {
   func getEmptyWord() -> String {
     var emptyMsg: String {
       switch nationality {
-      case "KO":
+      case Nationality.KO.rawValue:
         return "비어 있는"
-      case "EN":
+      case Nationality.EN.rawValue:
         return "Empty"
-      case "JA":
+      case Nationality.JA.rawValue:
         return "空っぽの"
-      case "FR":
+      case Nationality.FR.rawValue:
         return "Vide"
       case "CH":
         return "空"

--- a/GGomVoca/GGomVoca/View/WordListView/WordList/AddNewWordView.swift
+++ b/GGomVoca/GGomVoca/View/WordListView/WordList/AddNewWordView.swift
@@ -64,7 +64,7 @@ struct AddNewWordView: View {
                 }
                 
                 switch viewModel.selectedVocabulary.nationality {
-                case "KO", "JA":
+                case Nationality.KO.rawValue, Nationality.JA.rawValue:
                     Section(header: Text("발음")) {
                         TextField("발음을 입력하세요.", text: $inputOption, axis: .vertical)
                             .textInputAutocapitalization(.never)

--- a/GGomVoca/GGomVoca/View/WordListView/WordList/EditWordView.swift
+++ b/GGomVoca/GGomVoca/View/WordListView/WordList/EditWordView.swift
@@ -54,7 +54,7 @@ struct EditWordView: View {
                 }
                 
                 switch viewModel.selectedVocabulary.nationality {
-                case "KO", "JA":
+                case Nationality.KO.rawValue, Nationality.JA.rawValue:
                     Section(header: Text("발음")) {
                         TextField("발음을 입력하세요.", text: $inputOption, axis: .vertical)
                             .textInputAutocapitalization(.never)

--- a/GGomVoca/GGomVoca/View/WordListView/WordList/WordListViewModel.swift
+++ b/GGomVoca/GGomVoca/View/WordListView/WordList/WordListViewModel.swift
@@ -80,13 +80,13 @@ class WordListViewModel: ObservableObject {
   func getEmptyWord() -> String {
     var emptyMsg: String {
       switch nationality {
-      case "KO":
+      case Nationality.KO.rawValue:
         return "비어 있는"
-      case "EN":
+      case Nationality.EN.rawValue:
         return "Empty"
-      case "JA":
+      case Nationality.JA.rawValue:
         return "空っぽの"
-      case "FR":
+      case Nationality.FR.rawValue:
         return "Vide"
       case "CH":
         return "空"

--- a/GGomVoca/GGomVoca/View/WordListView/WordList/WordsTableView.swift
+++ b/GGomVoca/GGomVoca/View/WordListView/WordList/WordsTableView.swift
@@ -36,14 +36,14 @@ struct WordsTableView: View {
                 }
                 
                 switch viewModel.nationality {
-                case "KO", "JA":
+                case Nationality.KO.rawValue, Nationality.JA.rawValue:
                     Text("단어")
                         .headerText()
                     Text("발음")
                         .headerText()
                     Text("뜻")
                         .headerText()
-                case "EN", "FR":
+                case Nationality.EN.rawValue, Nationality.FR.rawValue:
                     Text("단어")
                         .headerText()
                     Text("뜻")
@@ -64,7 +64,7 @@ struct WordsTableView: View {
             List($viewModel.words, id: \.self, selection: $multiSelection) { $word in
                 HStack {
                     switch viewModel.nationality {
-                    case "KO", "JA":
+                    case Nationality.KO.rawValue, Nationality.JA.rawValue:
                         HStack {
                             Text(word.word ?? "")
                                 .listCellText(isSelectionMode: isSelectionMode)


### PR DESCRIPTION
## 개요
Nationality의 rawValue가 저장되고 쓰이는 것으로 로직을 변경한다.

## 작업사항
Vocabulary 의 Nationality 속성이 rawValue가 저장되도록 변경("KO" -> "한국어")

close : #5