### PR TITLE
Fix(LaunchScreen)

### DIFF
--- a/GGomVoca/GGomVoca/Launch Screen.storyboard
+++ b/GGomVoca/GGomVoca/Launch Screen.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
-    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <device id="ipad10_9rounded" orientation="landscape" layout="fullscreen" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -12,24 +12,18 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1180" height="820"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="launchIcon" translatesAutoresizingMaskIntoConstraints="NO" id="lVl-nH-5n4">
-                                <rect key="frame" x="76.666666666666686" y="305" width="240" height="242"/>
+                                <rect key="frame" x="470" y="290" width="240" height="240"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="242" id="Fm4-iX-x58"/>
+                                    <constraint firstAttribute="height" constant="240" id="Fm4-iX-x58"/>
                                     <constraint firstAttribute="width" constant="240" id="MsC-mW-BFv"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
-                                <rect key="frame" x="0.0" y="832" width="393" height="0.0"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="The Voca" textAlignment="center" lineBreakMode="tailTruncation" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rh4-PD-zl5">
-                                <rect key="frame" x="123" y="549" width="147" height="41"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TheVoca" textAlignment="center" lineBreakMode="tailTruncation" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rh4-PD-zl5">
+                                <rect key="frame" x="501.5" y="515" width="177" height="41"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="41" id="6cQ-wy-Prm"/>
                                     <constraint firstAttribute="width" constant="177" id="8VO-iu-X84"/>
@@ -42,15 +36,10 @@
                         <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
-                            <constraint firstItem="lVl-nH-5n4" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="DV3-uD-GhM"/>
-                            <constraint firstItem="Rh4-PD-zl5" firstAttribute="centerX" secondItem="lVl-nH-5n4" secondAttribute="centerX" id="EIH-KG-JPf"/>
-                            <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" symbolic="YES" id="SfN-ll-jLj"/>
-                            <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
-                            <constraint firstItem="lVl-nH-5n4" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Yqb-zs-6Lh"/>
-                            <constraint firstItem="lVl-nH-5n4" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="ZeV-ta-odd"/>
-                            <constraint firstItem="lVl-nH-5n4" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="og9-zh-oUB"/>
-                            <constraint firstItem="Rh4-PD-zl5" firstAttribute="top" secondItem="lVl-nH-5n4" secondAttribute="bottom" constant="-25" id="trY-pL-wNc"/>
+                            <constraint firstItem="Rh4-PD-zl5" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="MGh-a2-eur"/>
+                            <constraint firstItem="lVl-nH-5n4" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="eIv-oo-msL"/>
+                            <constraint firstItem="lVl-nH-5n4" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="qNy-C3-rr7"/>
+                            <constraint firstItem="Rh4-PD-zl5" firstAttribute="top" secondItem="lVl-nH-5n4" secondAttribute="bottom" constant="-15" id="qOU-tu-Mrc"/>
                         </constraints>
                     </view>
                 </viewController>


### PR DESCRIPTION
## 개요
- #21 

## 작업사항
- 기기를 회전하거나 다른 기기에서도 항상 로고와 앱이름이 가운데에 있도록 수정